### PR TITLE
Allow rendering BLAST results without pids or gids.

### DIFF
--- a/public/js/p3/widget/HomologyResultGrid.js
+++ b/public/js/p3/widget/HomologyResultGrid.js
@@ -18,7 +18,6 @@ define([
     state: null,
     storeType: '',
     columns: {},
-    loadingMessage: 'Loading homology results...',
 
     result_types: {
       'genome_feature': {
@@ -109,9 +108,36 @@ define([
           score: { label: 'Score', field: 'bitscore' },
           evalue: { label: 'E value', field: 'evalue' }
         }
-      }
-
+      },
+      'no_ids': {
+        container_type: 'fasta_data',
+        columns: {
+          'Selection Checkboxes': selector({ label: '', sortable: false, unhidable: true }),
+          expand: {
+            label: '',
+            field: '',
+            sortable: false,
+            unhidable: true,
+            renderCell: function (obj, val, node) {
+              node.innerHTML = '<div class="dgrid-expando-icon ui-icon ui-icon-triangle-1-e"></div>';
+            }
+          },
+          query: { label: 'Query ID', field: 'qseqid' },
+          patric_id: { label: 'Subject ID', field: 'sseqid' },
+          // na_length: { label: 'Length (NT)', field: 'na_length' },
+          // aa_length: { label: 'Length (AA)', field: 'aa_length' },
+          length: { label: 'ALN Length', field: 'length' },
+          identity: { label: 'Identity (%)', field: 'pident' },
+          q_coverage: { label: 'Query cover (%)', field: 'query_coverage' },
+          s_coverage: { label: 'Subject cover (%)', field: 'subject_coverage' },
+          hit_from: { label: 'Hit from', field: 'hit_from', hidden: true },
+          hit_to: { label: 'Hit to', field: 'hit_to', hidden: true },
+          score: { label: 'Score', field: 'bitscore' },
+          evalue: { label: 'E value', field: 'evalue' }
+        }
+      },
     },
+
     constructor: function (options, parent) {
       this.container = parent;
     },
@@ -131,7 +157,6 @@ define([
       } else {
         this.store.set('dataPath', dataPath)
       }
-
       this.refresh();
     },
 
@@ -151,7 +176,7 @@ define([
       if (this.storeType !== type) {
         this.storeType = type;
         this.container_type = this.result_types[type].container_type;
-        console.log('Set Container Type: ', this.container_type, 'storetype: ', this.storeType )
+        console.log('Set Container Type: ', this.container_type, 'storetype: ', this.storeType)
         this.container.set('containerType', this.container_type)
         this.set('columns', this.result_types[type].columns)
       }
@@ -263,8 +288,8 @@ define([
           hsp.positive ? 'Positives: ' + hsp.positive + '/' + hsp.align_len + '(' + Math.round(hsp.positive / hsp.align_len * 100) + '%)' : '',
           'Gaps: ' + hsp.gaps + '/' + hsp.align_len + '(' + Math.round(hsp.gaps / hsp.align_len * 100) + '%)',
           (hsp.query_frame || hsp.hit_frame) ? ('Frame: ' + (hsp.query_frame ? hsp.query_frame : '')
-                        + ((hsp.query_frame && hsp.hit_frame) ? '/' : '')
-                        + (hsp.hit_frame ? hsp.hit_frame : '')) : ''
+            + ((hsp.query_frame && hsp.hit_frame) ? '/' : '')
+            + (hsp.hit_frame ? hsp.hit_frame : '')) : ''
         ].join('    '));
         output.push('\n');
 


### PR DESCRIPTION
Using BLAST against a FASTA file that had no patric ids or genome ids was not displaying in the Homology viewer.
I fixed this so that FASTA files with no recognizable ids can be displayed in the viewer.