### PR TITLE
Enable disabling "dangling element" matching

### DIFF
--- a/public/js/p3/widget/app/MetagenomicBinning.js
+++ b/public/js/p3/widget/app/MetagenomicBinning.js
@@ -60,6 +60,21 @@ define([
       }
       this.numlibs.startup();
 
+      this.advrow.turnedOn = (this.advrow.style.display != 'none');
+      on(this.advanced, 'click', lang.hitch(this, function () {
+        this.advrow.turnedOn = (this.advrow.style.display != 'none');
+        if (!this.advrow.turnedOn) {
+          this.advrow.turnedOn = true;
+          this.advrow.style.display = 'block';
+          this.advicon.className = 'fa icon-caret-left fa-1';
+        }
+        else {
+          this.advrow.turnedOn = false;
+          this.advrow.style.display = 'none';
+          this.advicon.className = 'fa icon-caret-down fa-1';
+        }
+      }));
+
       this.pairToAttachPt.concat(this.singleToAttachPt).forEach(lang.hitch(this, function (attachname) {
         this[attachname].searchBox.validator = lang.hitch(this[attachname].searchBox, function (/* anything */ value, /* __Constraints */ constraints) {
           return (new RegExp('^(?:' + this._computeRegexp(constraints) + ')' + (this.required ? '' : '?') + '$')).test(value) &&
@@ -107,6 +122,12 @@ define([
         values.perform_bacterial_annotation = true;
         values.perform_viral_annotation = true;
       }
+	
+      if (this.disable_dangling.checked)
+      {
+	  values.danglen = 0;
+      }
+
       delete values['organism'];
 
       return values;

--- a/public/js/p3/widget/app/templates/MetagenomicBinning.html
+++ b/public/js/p3/widget/app/templates/MetagenomicBinning.html
@@ -181,6 +181,15 @@
                                 <div id="disable_dangling" data-dojo-type="dijit/form/CheckBox" data-dojo-attach-point="disable_dangling"></div>
                                 <label for="disable_dangling">Disable search for dangling contigs (decreases memory use)</label>
                   </div>
+                <div class="appRow" style="margin:0 0 0 0">
+                  <div class="appRowSegment" style="margin:0 0 0 0">
+                    <label class="paramlabel">Min. contig length</label><br>
+                    <div class="insertspinner" name="min_contig_len" data-dojo-type="dijit/form/NumberSpinner" data-dojo-attach-point="min_contig_len" data-dojo-props="value:400, smallDelta:10, constraints:{min:100,max:100000,places:0}, invalidMessage:'Please provide an integer value'"></div>
+                  </div>
+                  <div class="appRowSegment" style="margin:10px 0 0 0">
+                    <label class="paramlabel">Min. contig coverage</label><br>
+                    <div class="insertspinner" name="min_contig_cov" data-dojo-type="dijit/form/NumberSpinner" data-dojo-attach-point="min_contig_cov" data-dojo-props="value:4, smallDelta:1, constraints:{min:0,max:100000,places:0}, invalidMessage:'Please provide an integer value'"></div>
+                  </div>
 		  </div>
       </div>
     </div>

--- a/public/js/p3/widget/app/templates/MetagenomicBinning.html
+++ b/public/js/p3/widget/app/templates/MetagenomicBinning.html
@@ -166,6 +166,22 @@
           <label class="paramlabel">Genome Group Name</label><br>
           <div data-dojo-type="dijit/form/ValidationTextBox" name="genome_group" data-dojo-attach-point="genome_group" style="width: 300px" required="false" data-dojo-props="intermediateChanges:false, missingMessage:'You must provide a genome group name',trim:true,placeHolder:'My Genome Group'"></div>
         </div>
+              <div class="appRow">
+                <div class="appRowSegment" style="margin: 0 0 0 0;">
+                  <div data-dojo-attach-point="advanced" style="display:inline-block">
+                    <label class="largelabel">Advanced</label>
+                    <div class="iconbox" style="margin-left:0px">
+                      <i data-dojo-attach-point="advicon" class="fa icon-caret-down fa-1"></i>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="appRow" data-dojo-attach-point="advrow" style="display: none">
+                  <div class="appRow" style="margin:0 0 0 0">
+                                <div id="disable_dangling" data-dojo-type="dijit/form/CheckBox" data-dojo-attach-point="disable_dangling"></div>
+                                <label for="disable_dangling">Disable search for dangling contigs (decreases memory use)</label>
+                  </div>
+		  </div>
       </div>
     </div>
     <div class="appSubmissionArea">


### PR DESCRIPTION
Add a setting to set new parameter `danglen` to 0 if new advanced parameter 'disable dangling contigs' is set. 

cf Jira BVBRC-534; this should enable very large jobs to not run out of memory.