### PR TITLE
sudo userdel --force ccthomas@anl.gov

### DIFF
--- a/views/pages/team.ejs
+++ b/views/pages/team.ejs
@@ -27,7 +27,6 @@
                                 <li>Bruce Parrello</li>
                                 <li>Gordon Pusch</li>
                                 <li>Maulik Shukla</li>
-                                <li>Chris Thomas</li>
                                 <li>Margo VanOeffelen</li>
                                 <li>Veronika Vonstein</li>
                                 </ul>


### PR DESCRIPTION
Thought I could go ahead and take care of this one myself. The label 'enhancement' seemed to be the only one that fit at the moment though a tad cheeky I'd say. 