### PR TITLE
Fix widget conflict on Primer Design

### DIFF
--- a/public/js/p3/widget/app/templates/PrimerDesign.html
+++ b/public/js/p3/widget/app/templates/PrimerDesign.html
@@ -108,7 +108,7 @@
                                 </tr>
                             </table>
                             <div class="appRow">
-                                <div id="internal_oligo" data-dojo-type="dijit/form/CheckBox" data-dojo-attach-point="internal_oligo_checkbox" checked></div>
+                                <div data-dojo-type="dijit/form/CheckBox" data-dojo-attach-point="internal_oligo_checkbox" checked></div>
                                 <label for="internal_oligo">Pick Internal Oligo</label>
                             </div>
                             <div class="appRow">

--- a/public/js/p3/widget/app/templates/PrimerDesign.html
+++ b/public/js/p3/widget/app/templates/PrimerDesign.html
@@ -108,8 +108,8 @@
                                 </tr>
                             </table>
                             <div class="appRow">
-                                <div data-dojo-type="dijit/form/CheckBox" data-dojo-attach-point="internal_oligo_checkbox" checked></div>
-                                <label for="internal_oligo">Pick Internal Oligo</label>
+                                <div id="${id}_internal_oligo" data-dojo-type="dijit/form/CheckBox" data-dojo-attach-point="internal_oligo_checkbox" checked></div>
+                                <label for="${id}_internal_oligo">Pick Internal Oligo</label>
                             </div>
                             <div class="appRow">
                                 <label class="paramlabel">Product Size Ranges (bp)</label>


### PR DESCRIPTION
Issue: https://github.com/BV-BRC/issues/issues/1122

Using standard id attributes can cause conflicts in the routing system. The widget tries to create itself again but can't since the id is hard coded in the html template.

Relying on the dojo-attach-points is safer or incrementing the id attribute with a counter if you have to. In this case the .js file relies on the dojo attribute anyway.

@mshukla1 you may want to make mention of this for devs to be aware of. The MSA.html template has an incrementing example from @JacobPorter as well.