### PR TITLE
Changes related to output files for taxonomic classification service

### DIFF
--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -1,4 +1,4 @@
-fdefine([
+define([
   'dojo/_base/declare', 'dijit/_WidgetBase', 'dojo/on',
   'dojo/dom-class', 'dijit/_TemplatedMixin', 'dijit/_WidgetsInTemplateMixin',
   'dojo/text!./templates/AppLogin.html', 'dijit/form/Form', 'p3/widget/WorkspaceObjectSelector', 'dojo/topic', 'dojo/_base/lang',

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -1,4 +1,4 @@
-define([
+fdefine([
   'dojo/_base/declare', 'dijit/_WidgetBase', 'dojo/on',
   'dojo/dom-class', 'dijit/_TemplatedMixin', 'dijit/_WidgetsInTemplateMixin',
   'dojo/text!./templates/AppLogin.html', 'dijit/form/Form', 'p3/widget/WorkspaceObjectSelector', 'dojo/topic', 'dojo/_base/lang',
@@ -30,6 +30,7 @@ define([
     lookaheadError: null,
     lookaheadGif: null,
     maxFastaText: 64000,
+    ignoreMaxFastaTextLimit: false,
     help_doc: null,
     activeUploads: [],
     // srrValidationUrl: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?retmax=1&db=sra&field=accn&term={0}&retmode=json',

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -831,7 +831,7 @@ fdefine([
         message,
         trimFasta,
       };
-      if (fastaText.length > this.maxFastaText) {
+      if (!this.ignoreMaxFastaTextLimit && fastaText.length > this.maxFastaText) {
         reto.status = 'too_long';
         reto.message = 'The text input is too large. Save the data to a file.';
         return reto;

--- a/public/js/p3/widget/app/AppBase.js
+++ b/public/js/p3/widget/app/AppBase.js
@@ -30,7 +30,6 @@ define([
     lookaheadError: null,
     lookaheadGif: null,
     maxFastaText: 64000,
-    ignoreMaxFastaTextLimit: false,
     help_doc: null,
     activeUploads: [],
     // srrValidationUrl: 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?retmax=1&db=sra&field=accn&term={0}&retmode=json',
@@ -370,6 +369,21 @@ define([
       }
     },
 
+    checkForInvalidChars: function (value) {
+      var valid = true;
+      var invalid_chars = ['-', ':', '@', '"', "'", ';', '[', ']', '{', '}', '|', '`'];
+      invalid_chars.forEach(lang.hitch(this, function (char) {
+        if (value.includes(char)) {
+          valid = false;
+        }
+      }));
+      if (!valid) {
+        var msg = 'Remove invalid characters from name: - : @ " \' ; [ ] { } | `';
+        new Dialog({ title: 'Notice', content: msg }).show();
+      }
+      return valid;
+    },
+
     onAddSRRHelper: function (title) {
       this.srr_accession.set('state', '');
       if (!(typeof this.exp_design === 'undefined')) {
@@ -391,10 +405,20 @@ define([
         var lrec = { _type: 'srr_accession', title: title };
       }
       var chkPassed = this.ingestAttachPoints(toIngest, lrec);
+      var maybeSampleID;
+      if (chkPassed && ('srr_sample_id' in this)) {
+        maybeSampleID = this.srr_sample_id.get('displayedValue');
+        chkPassed = this.checkForInvalidChars(maybeSampleID);
+      }
       if (chkPassed) {
         var infoLabels = {
           title: { label: 'Title', value: 1 }
         };
+        if (maybeSampleID){
+          lrec.sample_id = maybeSampleID;
+          console.log(lrec.sample_id)
+        }
+
         this.addLibraryRow(lrec, infoLabels, 'srrdata');
       } else {
         throw new Error('Did not pass add library check. ');
@@ -806,7 +830,7 @@ define([
         message,
         trimFasta,
       };
-      if (!this.ignoreMaxFastaTextLimit && fastaText.length > this.maxFastaText) {
+      if (fastaText.length > this.maxFastaText) {
         reto.status = 'too_long';
         reto.message = 'The text input is too large. Save the data to a file.';
         return reto;

--- a/public/js/p3/widget/app/TaxonomicClassification.js
+++ b/public/js/p3/widget/app/TaxonomicClassification.js
@@ -463,7 +463,7 @@ define([
         return rrec;
       });
       if (this.sra_libs.length) {
-        values.srr_ids = this.sra_libs;
+        values.srr_libs = this.sra_libs;
       }
 
       // analysis type

--- a/public/js/p3/widget/app/TaxonomicClassification.js
+++ b/public/js/p3/widget/app/TaxonomicClassification.js
@@ -263,7 +263,6 @@ define([
 
     setSingleId: function () {
       var read_name = this.single_end_libsWidget.searchBox.get('displayedValue');
-      console.log(read_name)
       this.single_sample_id.set('value', this.replaceInvalidChars(read_name.split('.')[0]));
     },
 
@@ -303,7 +302,6 @@ define([
 
     setPairedId: function () {
       var read_name = this.read1.searchBox.get('displayedValue');
-      read_name = read_name.replace(/(R1|_R1_|r1|_r1_|r1_|_r1|R1_|_R1)/g, '');
       this.paired_sample_id.set('value', this.replaceInvalidChars(read_name.split('.')[0]));
     },
 
@@ -425,7 +423,6 @@ define([
       var pairedList = this.libraryStore.query({ _type: 'paired' });
       var singleList = this.libraryStore.query({ _type: 'single' });
       var srrAccessionList = this.libraryStore.query({ _type: 'srr_accession' });
-      console.log(srrAccessionList)
 
       this.paired_end_libs = pairedList.map(function (lrec) {
         var rrec = {};

--- a/public/js/p3/widget/viewer/File.js
+++ b/public/js/p3/widget/viewer/File.js
@@ -130,18 +130,22 @@ define([
                 domStyle.set(this.viewer.containerNode, 'overflow', 'hidden');
                 domConstruct.place(iframe, this.viewer.containerNode);
                 var iframe_contents = this.file.data;
-	        if (this.file.metadata.name == 'GenomeReport.html')
-	        {
-	          iframe_contents = iframe_contents.replaceAll('="https://www.patricbrc.org/view/Feature',
+                if (this.file.metadata.name == 'GenomeReport.html'){
+                          iframe_contents = iframe_contents.replaceAll('="https://www.patricbrc.org/view/Feature',
 							       '="' + window.App.appBaseURL + '/view/Feature');
-		}
+	             	}
 
-                var bookmark_regex = /<a\s+(?:[^>]*?\s+)?href=(["'])(#.*?)\1/gi;
-                if (iframe_contents.search(bookmark_regex)) {
-                  iframe_contents = iframe_contents.replace(/<a\s+(?:[^>]*?\s+)?href=(["'])(#.*?)\1/gi, '$&  onclick="return false;"');
+                iframe.onload = function(){
+                  var nodes = iframe.contentWindow.document.getElementsByTagName("a")
+                  var i=0
+                  while (i<nodes.length){
+                    var n = nodes.item(i)
+                    n.target="_parent";
+                    i++
+                  }
                 }
-
                 iframe.srcdoc = iframe_contents;
+
                 return;
               case 'json':
               case 'diffexp_experiment':


### PR DESCRIPTION
Hello Bob,
I made a small change to the taxonomic classification service .JS. I tried to remove R1 from sample ID but it as problematic with SRR#'s. I'm open to more robust solutions here.  File.JS has changes from Dustin to address the iframe issue described in [issue 1165](https://github.com/BV-BRC/issues/issues/1165). I went through my outputs (mostly from testing the rerun button) and didn't see any issues. But I would echo Dustin's comment in the meeting today to say that we should ask people to test their .HTML outputs to ensure they are not impacted by this change. 
Nicole 