### PR TITLE
Update default options for TaxonomicClassification.html

### DIFF
--- a/public/js/p3/widget/app/templates/TaxonomicClassification.html
+++ b/public/js/p3/widget/app/templates/TaxonomicClassification.html
@@ -168,7 +168,7 @@
         <div class="appRow">
             <label>Database</label><br>
             <select data-dojo-type="dijit/form/Select" name="database" style="width:300px" required="true" data-dojo-props="intermediateChanges:true">
-              <option value="bvbrc">BV-BRC Database</option>
+              <option value="bvbrc">BV-BRC Database selected="selected"</option>
               <option value="standard">Kraken2 Standard Database</option>
             </select>
         </div>
@@ -191,7 +191,7 @@
       <div class="appRow">
         <label>Confidence Interval</label><br>
         <select data-dojo-type="dijit/form/Select" name="confidence_interval" style="width:300px" required="true" data-dojo-props="intermediateChanges:true">
-          <option value="0.1">0.1</option>
+          <option value="0.1" selected="selected">0.1</option>
           <option value="0.2">0.2</option>
           <option value="0.3">0.3</option>
           <option value="0.4">0.4</option>

--- a/public/js/p3/widget/app/templates/TaxonomicClassification.html
+++ b/public/js/p3/widget/app/templates/TaxonomicClassification.html
@@ -168,8 +168,8 @@
         <div class="appRow">
             <label>Database</label><br>
             <select data-dojo-type="dijit/form/Select" name="database" style="width:300px" required="true" data-dojo-props="intermediateChanges:true">
-              <option value="standard">Kraken2 Standard Database</option>
               <option value="bvbrc">BV-BRC Database</option>
+              <option value="standard">Kraken2 Standard Database</option>
             </select>
         </div>
         <div class="appRow">
@@ -191,7 +191,6 @@
       <div class="appRow">
         <label>Confidence Interval</label><br>
         <select data-dojo-type="dijit/form/Select" name="confidence_interval" style="width:300px" required="true" data-dojo-props="intermediateChanges:true">
-          <option value="0">0</option>
           <option value="0.1">0.1</option>
           <option value="0.2">0.2</option>
           <option value="0.3">0.3</option>
@@ -202,6 +201,7 @@
           <option value="0.8">0.8</option>
           <option value="0.9">0.9</option>
           <option value="1">1</option>
+          <option value="0">0</option>
       </select>
     </div>
       <div class="appRow">


### PR DESCRIPTION
Hello,

I updated the default options by moving the default to the top of the list in the TaxonomicClassification.HTML file. Is there a better way to do this?

After emptying the cash and a hard reload I was unable to recreate the behavior of the invalid SRA Run Accession on alpha or in my local host- no changes were made regarding that error. I don't think we need any.

Let me know what you think about the default option or if you have any questions,
Nicole 