### PR TITLE
Fix to the commented code from the fastq utils edits

### DIFF
--- a/public/js/p3/widget/app/FastqUtil.js
+++ b/public/js/p3/widget/app/FastqUtil.js
@@ -28,7 +28,7 @@ define([
     pageTitle: 'Fastq Utilities Service | BV-BRC',
     libraryData: null,
     defaultPath: '',
-    startingRows: 12,
+    startingRows: 14,
     initConditions: 5,
     maxConditions: 5,
     hostGenomes: {

--- a/public/js/p3/widget/app/templates/FastqUtil.html
+++ b/public/js/p3/widget/app/templates/FastqUtil.html
@@ -30,7 +30,7 @@
       <table class="assemblyblocks" style="width:100%">
         <tr>
           <td>
-            <div id="pipelineBox" class="appBox appShadow" style="min-height: 170px; height:auto">
+            <div id="pipelineBox" class="appBox appShadow" style="min-height: 252px; height:auto">
               <div style="width:85%;display:inline-block;">
                 <label class="appBoxLabel">Parameters</label>
                 <div name="parameters" class="infobox iconbox infobutton dialoginfo">
@@ -158,46 +158,6 @@
                 <div data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-event="onChange:updateSRR"
                   data-dojo-attach-point="srr_accession" style="width: 300px" required="false"
                   data-dojo-props="intermediateChanges:true, missingMessage:'You must provide an accession', trim:true, placeHolder:'SRR'">
-            <!-- </div>
-            <div class="appBox appShadow">
-              <div class="headerrow">
-                <div style="width:85%;display:inline-block;">
-                  <label class="appBoxLabel">Single read library</label>
-                </div>
-                <div style="width:10%;display:inline-block;"><i data-dojo-attach-event="click:onAddSingle"
-                    class="fa icon-arrow-circle-o-right fa-lg"></i></div>
-              </div>
-              <div class="appRow">
-                <label class="paramlabel">Platform</label><br>
-                <select data-dojo-type="dijit/form/Select" name="platform_select"
-                  data-dojo-attach-point="platform_select" style="width:264px" required="true"
-                  data-dojo-props="intermediateChanges:true,trim:true,placeHolder:'Select Platform'">
-                  <option value="illumina">Illumina</option>
-                  <option value="pacbio">Pacbio</option>
-                  <option value="nanopore">Nanopore</option>
-                </select>
-              </div>
-              <div class="appRow">
-                <label class="paramlabel">Read File</label><br>
-                <div data-dojo-type="p3/widget/WorkspaceObjectSelector" name="libdat_readfile"
-                  data-dojo-attach-point="read" style="width:300px" required="false"
-                  data-dojo-props="type:['reads'],multi:false"></div>
-              </div>
-            </div>
-            <div class="appBox appShadow">
-              <div class="headerrow">
-                <div style="width:85%;display:inline-block;">
-                  <label class="appBoxLabel">SRA run accession</label>
-                </div>
-                <div style="width:10%;display:inline-block;"><i data-dojo-attach-event="click:onAddSRR"
-                    class="fa icon-arrow-circle-o-right fa-lg"></i></div>
-              </div>
-              <div class="appRow">
-                <label class="paramlabel">SRR Accession</label><i
-                  data-dojo-attach-point="srr_accession_validation_message"></i><br>
-                <div data-dojo-type="dijit/form/ValidationTextBox" data-dojo-attach-event="onChange:updateSRR"
-                  data-dojo-attach-point="srr_accession" style="width: 300px" required="false"
-                  data-dojo-props="intermediateChanges:true, missingMessage:'You must provide an accession', trim:true, placeHolder:'SRR'"> -->
                 </div>
               </div>
             </div>
@@ -212,7 +172,7 @@
                 <br>
                 <div class="appsublabel">Place read files here using the arrow buttons.</div>
               </div>
-              <div class="appRow" style="width:100%; margin-top:10px; text-align: center;">
+              <div class="appRow" style="width:100%; margin-top:10px; margin-bottom:3px; text-align: center;">
                 <table class="librarytable" frame="box" data-dojo-attach-point="libsTable"
                   style="margin:0 0 0 10px; width:90%;">
                   <tbody data-dojo-attach-point="libsTableBody">

--- a/public/js/p3/widget/app/templates/TaxonomicClassification.html
+++ b/public/js/p3/widget/app/templates/TaxonomicClassification.html
@@ -375,5 +375,3 @@
     </div>
   </div>
 </form>
-  </div>
-</form>


### PR DESCRIPTION
Hello Bob,

This pull request should address the following:
- remove the commented out code block from commit: 4e87d1ae84f8230ff8869020dc6a1ff3057f93ee
- conclude the fix to the Fastq Utils "i" icon
- address/improve the box alignment

The docs are already updated in BV-BRC-Docs PR: [12](https://github.com/BV-BRC/BV-BRC-Docs/pull/112).
Kind regards,
Nicole 