### PR TITLE
fixing NCBI Gene ID and NCBI GI Number dropdown values

### DIFF
--- a/public/js/p3/widget/app/templates/Expression.html
+++ b/public/js/p3/widget/app/templates/Expression.html
@@ -72,8 +72,8 @@
                                             required="true">
                                         <option selected="true" value="patric_id">BRC ID</option>
                                         <option value="feature_id">PATRIC Feature ID</option>
-                                        <option value="gi">NCBI GI Number</option>
-                                        <option value="gene_id">NCBI Gene ID</option>
+                                        <option value="gene_id">NCBI GI Number</option>
+                                        <option value="gene">NCBI Gene ID</option>
                                         <option value="protein_id">NCBI Protein ID</option>
                                         <option value="refseq_locus_tag">Refseq Locus Tag</option>
                                         <option value="alt_locus_tag">Alt. Locus Tag</option>


### PR DESCRIPTION
- The values for NCBI Gene ID and NCBI GI Number were not correct: NCBI Gene ID was set to an integer field when it should be a string, NCBI GI Number to an integer field mapped to a different field
- Updated NCBI Gene ID -> 'gene' (string)
- Updated NCBI GI Number -> 'gene_id' (integer)