### PR TITLE
Adding authorization headers and removing limit from pathways map query

### DIFF
--- a/public/js/p3/widget/viewer/PathwayMap.js
+++ b/public/js/p3/widget/viewer/PathwayMap.js
@@ -59,7 +59,7 @@ define([
     },
 
     sortGenomeIdsByTaxon: function (genome_ids) {
-      var query = `?in(genome_id,(${genome_ids}))&select(genome_id)&sort(+superkingdom,+phylum,+class,+order,+family,+genus,+genome_name)`;
+      var query = `?in(genome_id,(${genome_ids}))&select(genome_id)&limit(10000)&sort(+superkingdom,+phylum,+class,+order,+family,+genus,+genome_name)`;
       return when(request.get(PathJoin(this.apiServiceUrl, 'genome', query), {
         headers: {
           Accept: 'application/json',

--- a/public/js/p3/widget/viewer/PathwayMap.js
+++ b/public/js/p3/widget/viewer/PathwayMap.js
@@ -59,12 +59,12 @@ define([
     },
 
     sortGenomeIdsByTaxon: function (genome_ids) {
-
       var query = `?in(genome_id,(${genome_ids}))&select(genome_id)&sort(+superkingdom,+phylum,+class,+order,+family,+genus,+genome_name)`;
       return when(request.get(PathJoin(this.apiServiceUrl, 'genome', query), {
         headers: {
           Accept: 'application/json',
-          'Content-Type': 'application/rqlquery+x-www-form-urlencoded'
+          'Content-Type': 'application/rqlquery+x-www-form-urlencoded',
+          Authorization: window.App.authorizationToken
         },
         handleAs: 'json'
       }), function (response) {
@@ -80,7 +80,8 @@ define([
       return when(request.get(PathJoin(this.apiServiceUrl, 'genome', query), {
         headers: {
           Accept: 'application/json',
-          'Content-Type': 'application/rqlquery+x-www-form-urlencoded'
+          'Content-Type': 'application/rqlquery+x-www-form-urlencoded',
+          Authorization: window.App.authorizationToken
         },
         handleAs: 'json'
       }), function (response) {
@@ -96,7 +97,8 @@ define([
       return when(request.get(PathJoin(this.apiServiceUrl, 'pathway_ref', query), {
         headers: {
           Accept: 'application/json',
-          'Content-Type': 'application/rqlquery+x-www-form-urlencoded'
+          'Content-Type': 'application/rqlquery+x-www-form-urlencoded',
+          Authorization: window.App.authorizationToken
         },
         handleAs: 'json'
       }), function (response) {

--- a/public/js/p3/widget/viewer/PathwayMap.js
+++ b/public/js/p3/widget/viewer/PathwayMap.js
@@ -59,7 +59,7 @@ define([
     },
 
     sortGenomeIdsByTaxon: function (genome_ids) {
-      var query = `?in(genome_id,(${genome_ids}))&select(genome_id)&limit(10000)&sort(+superkingdom,+phylum,+class,+order,+family,+genus,+genome_name)`;
+      var query = `?in(genome_id,(${genome_ids}))&select(genome_id)&limit(25000)&sort(+superkingdom,+phylum,+class,+order,+family,+genus,+genome_name)`;
       return when(request.get(PathJoin(this.apiServiceUrl, 'genome', query), {
         headers: {
           Accept: 'application/json',


### PR DESCRIPTION
- Authorization header was lacking from pathways map genome query, resulting in empty PathwayMap views for private genomes
- Adding authorization header enables the view as expected
- A limit value was not present in the genome pathway map query which restricted the returned data
- Adding a limit and setting it arbitrarily high has removed this problem