### PR TITLE
Add Exemplar database and fix spacing across form

### DIFF
--- a/public/js/p3/widget/StructureIdSelector.js
+++ b/public/js/p3/widget/StructureIdSelector.js
@@ -16,7 +16,7 @@ define([
     apiServiceUrl: window.App.dataServiceURL,
     promptMessage: 'Structure ID.',
     missingMessage: 'Specify protein structure ID.',
-    placeHolder: 'e.g. 1AH5',
+    placeHolder: 'e.g. 1XFC',
     searchAttr: 'pdb_id',
     queryExpr: '${0}*',
     queryFilter: '',

--- a/public/js/p3/widget/app/templates/Docking.html
+++ b/public/js/p3/widget/app/templates/Docking.html
@@ -31,7 +31,7 @@
           <div class="appFieldLong">
             <label>PDB Id</label><br>
             <div data-dojo-type="p3/widget/StructureIdSelector" data-dojo-attach-point="pdb_list" name="pdb_id"
-              style="width:50%" data-dojo-attach-event="onChange:onPdbIdChange" required="true" data-dojo-props="">
+              style="width:65%" data-dojo-attach-event="onChange:onPdbIdChange" required="true" data-dojo-props="">
             </div>
 
             <input id="${id}_pdb_preview" data-dojo-type="dijit/form/Button" data-dojo-attach-point="pdb_preview"
@@ -50,40 +50,43 @@
           </div>
           <br>
           <div class="appRow">
-            <input id="${id}_smiles_text" type="radio" data-dojo-type="dijit/form/RadioButton"
-              data-dojo-attach-point="input_sequence" name="input" value="smiles_list"
-              data-dojo-attach-event="onChange:onInputChange" checked />
-            <label for="${id}_smiles_text">Enter smiles strings</label>
-            <input id="${id}_ws_file" type="radio" data-dojo-type="dijit/form/RadioButton"
-              data-dojo-attach-point="ws_file" name="input" value="ws_file"
-              data-dojo-attach-event="onChange:onInputChange" />
-            <label for="${id}_ws_file">Select file of smiles strings</label>
             <input id="${id}_ligand_named_library" type="radio" data-dojo-type="dijit/form/RadioButton"
             data-dojo-attach-point="ligand_named_library" name="input" value="named_library"
+            data-dojo-attach-event="onChange:onInputChange" checked />
+            <label for="${id}_ligand_named_library">Predefined Ligand Libraries</label>
+            <input id="${id}_ws_file" type="radio" data-dojo-type="dijit/form/RadioButton"
+            data-dojo-attach-point="ws_file" name="input" value="ws_file"
             data-dojo-attach-event="onChange:onInputChange" />
-          <label for="${id}_ligand_named_library">Predefined Ligand Libraries</label>
+            <label for="${id}_ws_file">Select file of smiles strings</label>
+            <input id="${id}_smiles_text" type="radio" data-dojo-type="dijit/form/RadioButton"
+              data-dojo-attach-point="input_sequence" name="input" value="smiles_list"
+              data-dojo-attach-event="onChange:onInputChange" />
+            <label for="${id}_smiles_text">Enter smiles strings</label>
           </div>
           <div data-dojo-attach-point="block_smiles_dropdown" style="height:100px;width:400px">
             <select data-dojo-type="dijit/form/Select"
             name="smiles_dropdown"
             value="smiles_dropdown_value"
             data-dojo-attach-point="smiles_dropdown"
+            style="width:100%;"
             data-dojo-props="intermediateChanges:true, missingMessage:'Please select from our options of predefined ligand libraries'"
             data-dojo-attach-event="onChange:onDropdownChange">
+            <option value="small_db">Exemplar Drug Compounds</option>
             <option value="approved-drugs">Approved Drug Compounds</option>
             <option value="experimental_drugs">Experimental Drug Compounds</option>
           </select>
         </div>
-          <div data-dojo-attach-point="block_smiles_text" style="height:100px; ">
+          <div data-dojo-attach-point="block_smiles_text" style="height:100px;">
             <textarea id="${id}_smiles_textarea" data-dojo-attach-point="smiles_text" name="smiles_text"
               style="resize: none; height:90%;width:96%; margin-left:10px; font-family: monospace; font-size:12px;"
               data-dojo-attach-point="sequence" data-dojo-type="dijit/form/SimpleTextarea"
               data-dojo-props="rows:13, placeholder:'Enter one or more SMILES strings, one per line.', intermediateChanges:true,  trim:true"></textarea>
           </div>
           <div data-dojo-attach-point="block_smiles_ws" style="height:100px;">
-
-            <div style="width:85%;display:inline-block; margin:auto;" data-dojo-type="p3/widget/WorkspaceObjectSelector"
-              name="smiles_ws_file" data-dojo-attach-point="smiles_ws_file"
+            <div display:inline-block; margin:auto;" data-dojo-type="p3/widget/WorkspaceObjectSelector"
+              name="smiles_ws_file" 
+              style="height:100px; width:75%";
+              data-dojo-attach-point="smiles_ws_file"
               data-dojo-props="type:['txt','unspecified'],multi:false,promptMessage:'Select or upload file of SMILES strings to your workspace.',missingMessage:'SMILES strings file is required.',placeHolder:'SMILES data file'">
             </div>
           </div>
@@ -104,7 +107,7 @@
           <div class="appFieldLong">
             <label>Output Folder</label><br>
             <div data-dojo-attach-point="output_path" data-dojo-type="p3/widget/WorkspaceObjectSelector"
-              name="output_path" style="width:100%" required="true"
+              name="output_path" style="width:75%" required="true"
               data-dojo-props="title:'Select an Output Folder',autoSelectCurrent:true,selectionText:'Destination',type:['folder'],multi:false,value:'${activeWorkspacePath}',workspace:'${activeWorkspace}',promptMessage:'The output folder for your Docking Results',missingMessage:'Output Folder must be selected.'"
               data-dojo-attach-event="onChange:onOutputPathChange"></div>
           </div>
@@ -115,7 +118,7 @@
             <label>Output Name</label><span class="charError"
               style="color:red; font-size:8pt; padding-left:10px; font-weight:bold">&nbsp;</span><br>
             <div data-dojo-attach-point="output_file" data-dojo-attach-event="onChange:checkOutputName"
-              style="width:380px; background-color:#F0F1F3"
+              style="width:100%;"
               data-dojo-type="p3/widget/WorkspaceFilenameValidationTextBox" name="output_file" required="true"
               data-dojo-props="intermediateChanges:true, promptMessage:'The output name for your Docking Results',missingMessage:'Output Name must be provided.',trim:true,placeHolder:'Output name'">
             </div>


### PR DESCRIPTION
Hello,
This pull request encompasses the following:
- addition of a Exemplar drug compounds to be used in workshops and as examples
- makes all fields the same length across the page
- reorders the input options with the ligand database as default

These changes have been tested and are ready to be further tested on alpha.
Kind regards,
Nicole 