### PR TITLE
fix: guard updateUserWorkspaceList when no DOM nodes exist

### DIFF
--- a/public/js/p3/app/p3app.js
+++ b/public/js/p3/app/p3app.js
@@ -829,64 +829,51 @@ define([
       });
     },
     updateUserWorkspaceList: function (data) {
-      var wsNode = dom.byId('YourWorkspaces');
-      domConstruct.empty('YourWorkspaces');
+      const wsNode = dom.byId('YourWorkspaces');
+      const wsMobileNode = dom.byId('YourWorkspaces-mobile');
 
-      let wsMobileNode = dom.byId('YourWorkspaces-mobile');
-      domConstruct.empty('YourWorkspaces-mobile');
+      // Check if Workspace DOM nodes exist; skip if not.
+      if (!wsNode && !wsMobileNode) {
+        return;
+      }
+
+      if (wsNode) domConstruct.empty(wsNode);
+      if (wsMobileNode) domConstruct.empty(wsMobileNode);
 
       const ws = data.find(d => d.name === 'home');
-      if (ws) {
-        var d = domConstruct.create('div', {style: {'padding-left': '12px'}}, wsNode);
+      if (!ws) return;
+
+      if (wsNode) {
+        const d = domConstruct.create('div', { style: { 'padding-left': '12px' } }, wsNode);
         domConstruct.create('i', {
           'class': 'fa icon-caret-down fa-1x noHoverIcon',
-          style: {'margin-right': '4px'}
+          style: { 'margin-right': '4px' }
         }, d);
         domConstruct.create('a', {
           'class': 'navigationLink',
           href: '/workspace' + ws.path,
           innerHTML: ws.name
         }, d);
-        domConstruct.create('a', {
-          href: '/workspace' + ws.path,
-          innerHTML: ws.name
-        }, wsMobileNode);
         domConstruct.create('br', {}, d);
-        domConstruct.create('a', {
-          'class': 'navigationLink',
-          'style': {'padding-left': '16px'},
-          href: '/workspace' + ws.path + '/Genome%20Groups',
-          innerHTML: 'Genome Groups'
-        }, d);
-        domConstruct.create('a', {
-          'style': {'padding-left': '16px'},
-          href: '/workspace' + ws.path + '/Genome%20Groups',
-          innerHTML: 'Genome Groups'
-        }, wsMobileNode);
-        domConstruct.create('br', {}, d);
-        domConstruct.create('a', {
-          'class': 'navigationLink',
-          'style': {'padding-left': '16px'},
-          href: '/workspace' + ws.path + '/Feature%20Groups',
-          innerHTML: 'Feature Groups'
-        }, d);
-        domConstruct.create('a', {
-          'style': {'padding-left': '16px'},
-          href: '/workspace' + ws.path + '/Feature%20Groups',
-          innerHTML: 'Feature Groups'
-        }, wsMobileNode);
-        domConstruct.create('br', {}, d);
-        domConstruct.create('a', {
-          'class': 'navigationLink',
-          'style': {'padding-left': '16px'},
-          href: '/workspace' + ws.path + '/Experiment%20Groups',
-          innerHTML: 'Experiment Groups'
-        }, d);
-        domConstruct.create('a', {
-          'style': {'padding-left': '16px'},
-          href: '/workspace' + ws.path + '/Experiment%20Groups',
-          innerHTML: 'Experiment Groups'
-        }, wsMobileNode);
+        ['Genome Groups', 'Feature Groups', 'Experiment Groups'].forEach(group => {
+          domConstruct.create('a', {
+            'class': 'navigationLink',
+            style: { 'padding-left': '16px' },
+            href: `/workspace${ws.path}/${encodeURIComponent(group)}`,
+            innerHTML: group
+          }, d);
+          domConstruct.create('br', {}, d);
+        });
+      }
+
+      if (wsMobileNode) {
+        ['home', 'Genome Groups', 'Feature Groups', 'Experiment Groups'].forEach(group => {
+          domConstruct.create('a', {
+            style: { 'padding-left': '16px' },
+            href: `/workspace${ws.path}/${encodeURIComponent(group)}`,
+            innerHTML: group
+          }, wsMobileNode);
+        });
       }
     }
   });


### PR DESCRIPTION
A check was added to  `updateUserWorkspaceList` in `p3app.js` to ensure that the DOM nodes it calls actually exist and prevents the return of `null`. An endless loop is entered that bogs done the user over time until either you quit the browser tab or the browser itself turns things off for you, forcing a the need for a new tab to be opened. 

![updateUserWorkspaceList](https://github.com/user-attachments/assets/a6975b40-5488-4877-807d-61ca20732cb3)

This can often occur if there are modifications to the related DOM elemets or CSS classes in `bv-brc-header.ejs`for the mobile and desktop navbars currently in use. If the DOM elements are not there then `updateUserWorkspaceList` is skipped.

Dojo’s `Topic.subscribe( ...... )` remains untouched as to not prevent `updateUserWorkspaceList` from still being utilized elsewhere throughout the app or even on the same view should that functionality ever be wanted/needed. 


