### PR TITLE
Update to JCVI personnel

### DIFF
--- a/views/pages/team.ejs
+++ b/views/pages/team.ejs
@@ -42,9 +42,7 @@
                                 <li>Anna Capria</li>
                                 <li>Mehmet Kuscuoglu</li>
                                 <li>Lucy Stewart</li>
-                                <li>Gene Tan</li>
                                 <li>Christian Zmasek</li>
-                                <li>Abril Zuniga</li>
                                 </ul>
                               </div>
                               <div class="virginia-team">


### PR DESCRIPTION
this PR removes JCVI personnel who are no longer active on the project.